### PR TITLE
Add Pocket CSV import feature

### DIFF
--- a/controller/link.go
+++ b/controller/link.go
@@ -2,8 +2,12 @@ package controller
 
 import (
 	"context"
+	"encoding/csv"
+	"io"
 	"net/http"
 	"reflect"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/linksort/linksort/analyze"
@@ -301,4 +305,139 @@ func doesFolderExist(u *model.User, folderID string) bool {
 	found := u.FolderTree.BFS(folderID)
 
 	return found != nil
+}
+
+func (l *Link) createLinkDirect(ctx context.Context, u *model.User, link *model.Link) (*model.Link, *model.User, error) {
+	op := errors.Op("controller.createLinkDirect")
+
+	var newLink *model.Link
+	var user *model.User
+	var err error
+
+	err = l.Transactor.DoInTransaction(context.Background(), func(sessCtx context.Context) error {
+		innerOp := errors.Opf("%s.innerTxn", op)
+
+		user, err = l.UserStore.GetUserByEmail(sessCtx, u.Email)
+		if err != nil {
+			return errors.E(innerOp, err)
+		}
+
+		newLink, err = l.Store.CreateLink(sessCtx, link)
+		if err != nil {
+			return errors.E(innerOp, err)
+		}
+
+		if err := user.TagTree.UpdateWithNewTagDetails(newLink.TagDetails); err != nil {
+			return errors.E(innerOp, err)
+		}
+
+		if _, err = l.UserStore.UpdateUser(sessCtx, user); err != nil {
+			return errors.E(innerOp, err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, nil, errors.E(op, err)
+	}
+
+	return newLink, user, nil
+}
+
+func (l *Link) ImportPocket(ctx context.Context, u *model.User, r io.Reader) (int, error) {
+	op := errors.Op("controller.ImportPocket")
+
+	reader := csv.NewReader(r)
+
+	headers, err := reader.Read()
+	if err != nil {
+		return 0, errors.E(op, err, http.StatusBadRequest)
+	}
+
+	idx := map[string]int{}
+	for i, h := range headers {
+		idx[strings.ToLower(strings.TrimSpace(h))] = i
+	}
+
+	count := 0
+
+	for {
+		rec, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return count, errors.E(op, err)
+		}
+
+		url := rec[idx["url"]]
+		title := ""
+		if i, ok := idx["title"]; ok {
+			title = rec[i]
+		}
+		ts := int64(0)
+		if i, ok := idx["time_added"]; ok {
+			ts, _ = strconv.ParseInt(rec[i], 10, 64)
+		}
+		tagsStr := ""
+		if i, ok := idx["tags"]; ok {
+			tagsStr = rec[i]
+		}
+
+		created := time.Unix(ts, 0)
+		if ts == 0 {
+			created = time.Now()
+		}
+
+		tagDetails := make(model.TagDetailList, 0)
+		pathsSet := map[string]struct{}{}
+		if tagsStr != "" {
+			for _, t := range strings.Split(tagsStr, "|") {
+				t = strings.TrimSpace(t)
+				if t == "" {
+					continue
+				}
+				tagDetails = append(tagDetails, &model.TagDetail{Name: t, Path: t, Confidence: 1})
+				parts := strings.Split(t, "/")
+				if len(parts) > 0 && parts[0] == "" {
+					parts = parts[1:]
+				}
+				for i := range parts {
+					pathsSet[strings.Join(parts[:i+1], "/")] = struct{}{}
+				}
+			}
+		}
+
+		tagPaths := make([]string, 0, len(pathsSet))
+		for p := range pathsSet {
+			tagPaths = append(tagPaths, p)
+		}
+
+		link := &model.Link{
+			UserID:     u.ID,
+			CreatedAt:  created,
+			UpdatedAt:  created,
+			URL:        url,
+			Title:      title,
+			TagDetails: tagDetails,
+			TagPaths:   tagPaths,
+		}
+
+		_, updatedUser, err := l.createLinkDirect(ctx, u, link)
+		if err != nil {
+			if e, ok := err.(*errors.Error); ok {
+				if e.Status() == http.StatusBadRequest && e.Message()["url"] == "This link has already been saved." {
+					// skip duplicates
+					continue
+				}
+			}
+
+			return count, errors.E(op, err)
+		}
+
+		*u = *updatedUser
+		count++
+	}
+
+	return count, nil
 }

--- a/frontend/src/pages/Account.jsx
+++ b/frontend/src/pages/Account.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { pick } from "lodash";
 import { useFormik } from "formik";
 import {
@@ -22,6 +22,7 @@ import {
   HStack,
 } from "@chakra-ui/react";
 import { ArrowForwardIcon } from "@chakra-ui/icons";
+import { csrfStore } from "../utils/apiFetch";
 
 import { suppressMutationErrors } from "../utils/mutations";
 import { useUpdateUser, useDeleteUser, useUser } from "../hooks/auth";
@@ -126,18 +127,30 @@ function APIAccess() {
         API Access
       </Heading>
 
-      <Text>
-        Use this API key to access Linksort programatically.
-      </Text>
+      <Text>Use this API key to access Linksort programatically.</Text>
 
       <Input
-        value={isShowing ? user.token : user.token.slice(-4).padStart(user.token.length, '*')}
+        value={
+          isShowing
+            ? user.token
+            : user.token.slice(-4).padStart(user.token.length, "*")
+        }
         isReadOnly
-        fontFamily={"mono"} />
+        fontFamily={"mono"}
+      />
 
       <HStack>
-        <Button onClick={() => setIsShowing(!isShowing)}>{isShowing ? "Hide" : "Show"} Key</Button>
-        <Button as="a" href="/docs" target="_blank" rightIcon={<ArrowForwardIcon />} >API Docs</Button>
+        <Button onClick={() => setIsShowing(!isShowing)}>
+          {isShowing ? "Hide" : "Show"} Key
+        </Button>
+        <Button
+          as="a"
+          href="/docs"
+          target="_blank"
+          rightIcon={<ArrowForwardIcon />}
+        >
+          API Docs
+        </Button>
       </HStack>
     </VStack>
   );
@@ -151,12 +164,71 @@ function DownloadData() {
       </Heading>
 
       <Text>
-        This will download a ZIP file containing all of your data in JSON format.
+        This will download a ZIP file containing all of your data in JSON
+        format.
       </Text>
 
       <Box>
-        <Button as="a" href="/api/users/download" download="linksort-data.zip">Download Data</Button>
+        <Button as="a" href="/api/users/download" download="linksort-data.zip">
+          Download Data
+        </Button>
       </Box>
+    </VStack>
+  );
+}
+
+function ImportPocket() {
+  const inputRef = useRef();
+  const toast = useToast();
+  const [isUploading, setIsUploading] = useState(false);
+
+  async function handleChange(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+    const form = new FormData();
+    form.append("file", file);
+    setIsUploading(true);
+    try {
+      await fetch("/api/links/import-pocket", {
+        method: "POST",
+        body: form,
+        headers: { "X-Csrf-Token": csrfStore.get() },
+        credentials: "same-origin",
+      });
+      toast({
+        title: "Import complete",
+        status: "success",
+        duration: 9000,
+        isClosable: true,
+      });
+    } catch (e) {
+      toast({
+        title: "Import failed",
+        status: "error",
+        duration: 9000,
+        isClosable: true,
+      });
+    }
+    setIsUploading(false);
+    if (inputRef.current) inputRef.current.value = "";
+  }
+
+  return (
+    <VStack maxWidth="40ch" spacing={4} align="left">
+      <Heading as="h2" size="md">
+        Import from Pocket
+      </Heading>
+      <input
+        ref={inputRef}
+        id="pocket-file"
+        type="file"
+        accept=".csv"
+        style={{ display: "none" }}
+        onChange={handleChange}
+      />
+      <Button as="label" htmlFor="pocket-file" isLoading={isUploading}>
+        Upload CSV
+      </Button>
     </VStack>
   );
 }
@@ -170,11 +242,7 @@ function Danger() {
   });
 
   return (
-    <VStack
-      maxWidth="40ch"
-      spacing={4}
-      align="left"
-    >
+    <VStack maxWidth="40ch" spacing={4} align="left">
       <Heading as="h2" size="md">
         Danger
       </Heading>
@@ -193,7 +261,8 @@ function Danger() {
               Are you sure you want to delete your account?
             </Text>
             <Text fontSize={"md"} fontWeight={"normal"}>
-              This action cannot be reversed and it will not be possible to recover your data.
+              This action cannot be reversed and it will not be possible to
+              recover your data.
             </Text>
             <HStack justifyContent={"flex-end"}>
               <Button
@@ -201,10 +270,13 @@ function Danger() {
                 color={"white"}
                 type="submit"
                 onClick={formik.handleSubmit}
-                isLoading={formik.isSubmitting}>
+                isLoading={formik.isSubmitting}
+              >
                 Yes, Delete
               </Button>
-              <Button onClick={onClose} autoFocus>No, Cancel</Button>
+              <Button onClick={onClose} autoFocus>
+                No, Cancel
+              </Button>
             </HStack>
           </VStack>
         </ModalContent>
@@ -238,6 +310,7 @@ export default function Account() {
     >
       <Profile />
       <APIAccess />
+      <ImportPocket />
       <DownloadData />
       <Danger />
     </VStack>

--- a/handler/link/link.go
+++ b/handler/link/link.go
@@ -3,6 +3,7 @@ package link
 import (
 	"context"
 	"html"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -24,6 +25,7 @@ type Config struct {
 		UpdateLink(context.Context, *model.User, *UpdateLinkRequest) (*model.Link, *model.User, error)
 		DeleteLink(context.Context, *model.User, string) (*model.User, error)
 		SummarizeLink(context.Context, *model.User, string) (*model.Link, error)
+		ImportPocket(context.Context, *model.User, io.Reader) (int, error)
 	}
 	AuthController interface {
 		WithCookie(context.Context, string) (*model.User, error)
@@ -43,6 +45,7 @@ func Handler(c *Config) *mux.Router {
 	r.Use(middleware.WithUser(c.AuthController, c.CSRF))
 
 	r.HandleFunc("/api/links", cc.CreateLink).Methods("POST")
+	r.HandleFunc("/api/links/import-pocket", cc.ImportPocket).Methods("POST")
 	r.HandleFunc("/api/links/{linkID}", cc.GetLink).Methods("GET")
 	r.HandleFunc("/api/links", cc.GetLinks).Methods("GET")
 	r.HandleFunc("/api/links/{linkID}/summarize", cc.SummarizeLink).Methods("POST")
@@ -313,6 +316,41 @@ func (s *config) DelteLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	payload.Write(w, r, &DeleteLinkResponse{user}, http.StatusOK)
+}
+
+type ImportPocketResponse struct {
+	Imported int `json:"imported"`
+}
+
+// ImportPocket godoc
+//
+//	@Summary        Import links from Pocket CSV
+//	@Param  file    formData        file    true    "CSV file"
+//	@Success        200     {object}        ImportPocketResponse
+//	@Failure        400     {object}        payload.Error
+//	@Failure        401     {object}        payload.Error
+//	@Failure        500     {object}        payload.Error
+//	@Security       ApiKeyAuth
+//	@Router /links/import-pocket  [post]
+func (s *config) ImportPocket(w http.ResponseWriter, r *http.Request) {
+	op := errors.Op("handler.ImportPocket")
+	ctx := r.Context()
+	u := middleware.UserFromContext(ctx)
+
+	f, _, err := r.FormFile("file")
+	if err != nil {
+		payload.WriteError(w, r, errors.E(op, err, http.StatusBadRequest))
+		return
+	}
+	defer f.Close()
+
+	n, err := s.LinkController.ImportPocket(ctx, u, f)
+	if err != nil {
+		payload.WriteError(w, r, errors.E(op, err))
+		return
+	}
+
+	payload.Write(w, r, &ImportPocketResponse{Imported: n}, http.StatusOK)
 }
 
 type SummarizeLinkResponse struct {

--- a/integ/link_test.go
+++ b/integ/link_test.go
@@ -1,8 +1,11 @@
 package integ_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"testing"
 	"time"
@@ -455,4 +458,42 @@ func TestSummarizeLink(t *testing.T) {
 			tt.End()
 		})
 	}
+}
+
+func TestImportPocket(t *testing.T) {
+	ctx := context.Background()
+	usr, _ := testutil.NewUser(t, ctx)
+
+	csvData := "title,url,time_added,cursor,tags,status\n" +
+		"Example,https://example.com,1728576752,1,tag1|tag2,unread\n" +
+		"Second,https://second.com,1728576753,2,,unread\n"
+
+	apitest.New("import").
+		Handler(testutil.Handler()).
+		Intercept(func(req *http.Request) {
+			buf := new(bytes.Buffer)
+			w := multipart.NewWriter(buf)
+			part, _ := w.CreateFormFile("file", "links.csv")
+			part.Write([]byte(csvData))
+			w.Close()
+			req.Body = io.NopCloser(buf)
+			req.Header.Set("Content-Type", w.FormDataContentType())
+			req.ContentLength = int64(buf.Len())
+		}).
+		Post("/api/links/import-pocket").
+		Header("X-Csrf-Token", testutil.UserCSRF(usr.SessionID)).
+		Cookie("session_id", usr.SessionID).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(jsonpath.Equal("$.imported", 2)).
+		End()
+
+	apitest.New("list").
+		Handler(testutil.Handler()).
+		Get("/api/links").
+		Cookie("session_id", usr.SessionID).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(jsonpath.Len("$.links", 2)).
+		End()
 }


### PR DESCRIPTION
## Summary
- allow uploading Pocket CSV files via `/api/links/import-pocket`
- parse CSV rows to create links and update user tags
- expose import endpoint through frontend account page
- cover new functionality in integration tests

## Testing
- `go test ./...` *(fails: server selection error)*
- `yarn test --watchAll=false` *(fails: package isn't in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687bd90357b48322933a395f7646994e