### PR TITLE
Fix DeleteLink handler name and update docs

### DIFF
--- a/handler/link/link.go
+++ b/handler/link/link.go
@@ -47,7 +47,7 @@ func Handler(c *Config) *mux.Router {
 	r.HandleFunc("/api/links", cc.GetLinks).Methods("GET")
 	r.HandleFunc("/api/links/{linkID}/summarize", cc.SummarizeLink).Methods("POST")
 	r.HandleFunc("/api/links/{linkID}", cc.UpdateLink).Methods("PATCH")
-	r.HandleFunc("/api/links/{linkID}", cc.DelteLink).Methods("DELETE")
+	r.HandleFunc("/api/links/{linkID}", cc.DeleteLink).Methods("DELETE")
 
 	return r
 }
@@ -298,7 +298,7 @@ type DeleteLinkResponse struct {
 //	@Failure	500					{object}	payload.Error
 //	@Security		ApiKeyAuth
 //	@Router	/links/{id}				[delete]
-func (s *config) DelteLink(w http.ResponseWriter, r *http.Request) {
+func (s *config) DeleteLink(w http.ResponseWriter, r *http.Request) {
 	op := errors.Op("handler.DeleteLink")
 	ctx := r.Context()
 	u := middleware.UserFromContext(ctx)
@@ -329,7 +329,7 @@ type SummarizeLinkResponse struct {
 //	@Failure		404			{object}	payload.Error
 //	@Failure		500			{object}	payload.Error
 //	@Security		ApiKeyAuth
-//	@Router		/links/{id}/summarize	[get]
+//	@Router		/links/{id}/summarize	[post]
 func (s *config) SummarizeLink(w http.ResponseWriter, r *http.Request) {
 	op := errors.Op("handler.SummarizeLink")
 	ctx := r.Context()


### PR DESCRIPTION
## Summary
- fix typo in DeleteLink handler name
- update router to use the corrected handler
- document SummarizeLink as POST instead of GET

## Testing
- `go test ./...` *(fails: server selection timeout for MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_687bd70f1e208322a95e4d58d1381fcd