### PR TITLE
Add toggle functionality for chat sidepanel visibility

### DIFF
--- a/frontend/src/components/AppLayout.jsx
+++ b/frontend/src/components/AppLayout.jsx
@@ -5,15 +5,19 @@ import Sidebar from "./Sidebar";
 import Header from "./Header";
 import ChatSidepanel from "./ChatSidepanel";
 import { HEADER_HEIGHT } from "../theme/theme";
+import { useLocalStorage } from "../hooks/localStorage";
 
 export default function AppLayout({ children }) {
+  const [isChatVisible, setIsChatVisible] = useLocalStorage("isChatVisible", true);
+  const toggleChat = () => setIsChatVisible(!isChatVisible);
+
   return (
     <Container maxWidth="100vw" px={0} position="relative" overflowX="hidden">
       <Grid
         maxWidth="100%"
         width="100%"
         minHeight="100vh"
-        templateColumns={["1fr", "1fr", "1fr", "1fr", "18rem 1fr", "18rem 1fr 25rem"]}
+        templateColumns={["1fr", "1fr", "1fr", "1fr", "18rem 1fr", isChatVisible ? "18rem 1fr 25rem" : "18rem 1fr"]}
       >
         <GridItem
           height="100%"
@@ -31,7 +35,7 @@ export default function AppLayout({ children }) {
             "calc(100vw)",
             "calc(100vw)",
             "calc(100vw - 18rem)",
-            "calc(100vw - 18rem - 25rem)",
+            isChatVisible ? "calc(100vw - 18rem - 25rem)" : "calc(100vw - 18rem)",
           ]}
         >
           <Box
@@ -41,7 +45,7 @@ export default function AppLayout({ children }) {
             left={["0", "0", "0", "0", "18rem", "18rem"]}
             zIndex={10}
           >
-            <Header />
+            <Header isChatVisible={isChatVisible} onToggleChat={toggleChat} />
           </Box>
           <Box as="main" marginTop={HEADER_HEIGHT} marginX="auto" width="100%">
             {children}
@@ -50,7 +54,7 @@ export default function AppLayout({ children }) {
         <GridItem
           width="25rem"
           height="100vh"
-          display={["none", "none", "none", "none", "none", "block"]}
+          display={["none", "none", "none", "none", "none", isChatVisible ? "block" : "none"]}
         >
           <ChatSidepanel />
         </GridItem>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -25,7 +25,7 @@ import ChatSidepanel from "./ChatSidepanel"
 import GiveFeedbackButton from "./GiveFeedbackButton";
 import { useScrollPosition } from "../hooks/utils";
 
-export default function Header() {
+export default function Header({ isChatVisible, onToggleChat }) {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const buttonRef = useRef();
   const { isOpen: isChatOpen, onOpen: onChatOpen, onClose: onChatClose } = useDisclosure();
@@ -85,7 +85,7 @@ export default function Header() {
         "calc(100vw)",
         "calc(100vw)",
         "calc(100vw - 18rem)",
-        "calc(100vw - 18rem - 25rem)",
+        isChatVisible ? "calc(100vw - 18rem - 25rem)" : "calc(100vw - 18rem)",
       ]}
     >
       <Flex
@@ -131,6 +131,14 @@ export default function Header() {
           <GiveFeedbackButton>
             <Button>Give Feedback</Button>
           </GiveFeedbackButton>
+          <IconButton
+            display={["none", "none", "none", "none", "none", "flex"]}
+            onClick={onToggleChat}
+            aria-label={isChatVisible ? "Hide chat" : "Show chat"}
+            zIndex={10}
+            icon={<ChatIcon />}
+            variant={isChatVisible ? "solid" : "outline"}
+          />
           <IconButton
             display={["flex", "flex", "flex", "flex", "flex", "none"]}
             id="mobile-nav"


### PR DESCRIPTION
## Summary
This PR adds the ability to toggle the chat sidepanel visibility on desktop views, with the state persisted to local storage. Users can now hide/show the chat panel using a new button in the header.

## Key Changes
- Integrated `useLocalStorage` hook in `AppLayout` to persist chat visibility state across sessions
- Added `isChatVisible` state management and `toggleChat` function to control chat panel display
- Updated grid layout to dynamically adjust column widths based on chat visibility state
- Modified `Header` component to accept `isChatVisible` and `onToggleChat` props
- Added chat toggle button to the header (visible only on desktop/largest breakpoint)
- Updated responsive width calculations for the main content area to account for hidden chat panel
- Chat sidepanel now conditionally renders based on visibility state while maintaining responsive behavior

## Implementation Details
- The chat visibility state is stored in localStorage under the key `"isChatVisible"` with a default value of `true`
- The toggle button uses a `ChatIcon` and displays as solid when chat is visible, outline when hidden
- Grid template columns and width calculations are conditional, ensuring proper layout whether the chat panel is shown or hidden
- The toggle button is only displayed on the largest breakpoint (desktop) where the chat panel is normally visible

https://claude.ai/code/session_019iEQaAy3DMAMnn7xHM9E8G